### PR TITLE
Read configuration from environment variables during execution instead of import

### DIFF
--- a/cloudns_api/api.py
+++ b/cloudns_api/api.py
@@ -28,34 +28,27 @@ from requests.exceptions import (
     ReadTimeout,
 )
 
-from .config import (
-    CLOUDNS_API_AUTH_ID,
-    CLOUDNS_API_AUTH_PASSWORD,
-    CLOUDNS_API_DEBUG,
-    CLOUDNS_API_SUB_AUTH_ID,
-    CLOUDNS_API_SUB_AUTH_USER,
-    CLOUDNS_API_TESTING,
-)
+from .config import get_config
 from .validation import ValidationError
 
 
 def get_auth_params():
     """Returns a dict pre-populated with auth parameters."""
     # Get password parameter
-    if not CLOUDNS_API_TESTING and not CLOUDNS_API_AUTH_PASSWORD:  # pragma: no cover
+    if not get_config('CLOUDNS_API_TESTING') and not get_config('CLOUDNS_API_AUTH_PASSWORD'):  # pragma: no cover
         raise EnvironmentError(
             'Environment variable "CLOUDNS_API_AUTH_PASSWORD" not set.'
         )
-    auth_params = {'auth-password': CLOUDNS_API_AUTH_PASSWORD}
+    auth_params = {'auth-password': get_config('CLOUDNS_API_AUTH_PASSWORD')}
 
     # Get username parameter
-    if CLOUDNS_API_AUTH_ID:
-        auth_params['auth-id'] = CLOUDNS_API_AUTH_ID
-    elif CLOUDNS_API_SUB_AUTH_ID:
-        auth_params['sub-auth-id'] = CLOUDNS_API_SUB_AUTH_ID
-    elif CLOUDNS_API_SUB_AUTH_USER:
-        auth_params['sub-auth-user'] = CLOUDNS_API_SUB_AUTH_USER
-    elif not CLOUDNS_API_TESTING:  # pragma: no cover
+    if get_config('CLOUDNS_API_AUTH_ID'):
+        auth_params['auth-id'] = get_config('CLOUDNS_API_AUTH_ID')
+    elif get_config('CLOUDNS_API_SUB_AUTH_ID'):
+        auth_params['sub-auth-id'] = get_config('CLOUDNS_API_SUB_AUTH_ID')
+    elif get_config('CLOUDNS_API_SUB_AUTH_USER'):
+        auth_params['sub-auth-user'] = get_config('CLOUDNS_API_SUB_AUTH_USER')
+    elif not get_config('CLOUDNS_API_TESTING'):  # pragma: no cover
         raise EnvironmentError(
             'No environment variable "CLOUDNS_API_AUTH_ID", '
             '"CLOUDNS_API_SUB_AUTH_ID" or "CLOUDNS_API_SUB_AUTH_USER" is set.'
@@ -175,7 +168,7 @@ class ApiResponse(object):
         if self.validation_errors:
             json['validation_errors'] = self.validation_errors
 
-        if CLOUDNS_API_DEBUG and not self.success and not self.error:
+        if get_config('CLOUDNS_API_DEBUG') and not self.success and not self.error:
             json['error'] = \
                 'Response has not yet been created with a requests.response.'
 
@@ -240,7 +233,7 @@ def api(api_call):
             response.error = 'API Connection timed out.'
             response.status_code = code.GATEWAY_TIMEOUT
 
-            if CLOUDNS_API_DEBUG:  # pragma: no cover
+            if get_config('CLOUDNS_API_DEBUG'):  # pragma: no cover
                 response.error = str(e)
 
         # Catch Connection errors
@@ -249,7 +242,7 @@ def api(api_call):
             response.error = 'API Network Connection error.'
             response.status_code = code.SERVER_ERROR
 
-            if CLOUDNS_API_DEBUG:  # pragma: no cover
+            if get_config('CLOUDNS_API_DEBUG'):  # pragma: no cover
                 response.error = str(e)
 
         # Catch API reported exceptions
@@ -268,10 +261,10 @@ def api(api_call):
             response.error = 'Something went wrong.'
             response.status_code = code.SERVER_ERROR
 
-            if CLOUDNS_API_DEBUG:
+            if get_config('CLOUDNS_API_DEBUG'):
                 response.error = str(e)
 
-            if CLOUDNS_API_TESTING:
+            if get_config('CLOUDNS_API_TESTING'):
                 import traceback
                 print('\n' + traceback.format_exc())
 

--- a/cloudns_api/config.py
+++ b/cloudns_api/config.py
@@ -21,13 +21,8 @@ def _is_true(env_var):
         return False
     return env_var.lower() in [1, 'true', 'yes']
 
-
-CLOUDNS_API_TESTING = _is_true(environ.get('CLOUDNS_API_TESTING'))
-
-CLOUDNS_API_AUTH_ID = environ.get('CLOUDNS_API_AUTH_ID')
-CLOUDNS_API_SUB_AUTH_ID = environ.get('CLOUDNS_API_SUB_AUTH_ID')
-CLOUDNS_API_SUB_AUTH_USER = environ.get('CLOUDNS_API_SUB_AUTH_USER')
-
-CLOUDNS_API_AUTH_PASSWORD = environ.get('CLOUDNS_API_AUTH_PASSWORD')
-
-CLOUDNS_API_DEBUG = _is_true(environ.get('CLOUDNS_API_DEBUG'))
+def get_config(env_var):
+    if env_var in ['CLOUDNS_API_TESTING', 'CLOUDNS_API_DEBUG']:
+        return _is_true(environ.get(env_var))
+    else:
+        return environ.get(env_var)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,6 +10,7 @@
 Mock helpers for cloudns_api unit tests.
 """
 
+from os import environ
 from mock import patch
 
 from cloudns_api.api import RequestResponseStub
@@ -23,22 +24,22 @@ TEST_PASSWORD = 'test-auth-password'
 
 
 def use_test_auth(test_fn):
-    @patch('cloudns_api.api.CLOUDNS_API_AUTH_ID', new=TEST_ID)
-    @patch('cloudns_api.api.CLOUDNS_API_AUTH_PASSWORD', new=TEST_PASSWORD)
+    @patch.dict(environ, {'CLOUDNS_API_AUTH_ID': TEST_ID})
+    @patch.dict(environ, {'CLOUDNS_API_AUTH_PASSWORD': TEST_PASSWORD})
     def test_wrapper(*args, **kwargs):
         test_fn(*args, test_id=TEST_ID, test_password=TEST_PASSWORD, **kwargs)
     return test_wrapper
 
 
 def set_debug(test_fn):
-    @patch('cloudns_api.api.CLOUDNS_API_DEBUG', new=True)
+    @patch.dict(environ, {'CLOUDNS_API_DEBUG': 'true'})
     def test_wrapper(*args, **kwargs):
         test_fn(*args, **kwargs)
     return test_wrapper
 
 
 def set_no_debug(test_fn):
-    @patch('cloudns_api.api.CLOUDNS_API_DEBUG', new=False)
+    @patch.dict(environ, {'CLOUDNS_API_DEBUG': 'false'})
     def test_wrapper(*args, **kwargs):
         test_fn(*args, **kwargs)
     return test_wrapper

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,7 @@
 Functional tests for cloudns_api's api utilities module.
 """
 
+from os import environ
 from mock import patch
 from requests import exceptions as request_exceptions
 
@@ -46,17 +47,17 @@ def test_get_auth_params_returns_auth_params(test_id, test_password):
     assert auth_params['auth-password'] == test_password
 
 
-@patch('cloudns_api.api.CLOUDNS_API_SUB_AUTH_ID', new=123)
-@patch('cloudns_api.api.CLOUDNS_API_AUTH_ID', new=None)
+@patch.dict(environ, {'CLOUDNS_API_SUB_AUTH_ID': '123'})
+@patch.dict(environ, {'CLOUDNS_API_AUTH_ID': ''})
 def test_get_auth_params_returns_sub_auth_id():
     """Function get_auth_params() returns sub auth params."""
     auth_params = get_auth_params()
-    assert auth_params['sub-auth-id'] == 123
+    assert auth_params['sub-auth-id'] == '123'
     assert 'auth-id' not in auth_params
 
 
-@patch('cloudns_api.api.CLOUDNS_API_SUB_AUTH_USER', new='sub-user')
-@patch('cloudns_api.api.CLOUDNS_API_AUTH_ID', new=None)
+@patch.dict(environ, {'CLOUDNS_API_SUB_AUTH_USER': 'sub-user'})
+@patch.dict(environ, {'CLOUDNS_API_AUTH_ID': ''})
 def test_get_auth_params_returns_sub_auth_user():
     """Function get_auth_params() returns sub auth params."""
     auth_params = get_auth_params()


### PR DESCRIPTION
As mentioned in #9 the configuration was read from environment variables during import. So when someone imports this module, then runs code to set environment variables (like dotenv), the changes are not taken into account by cloudns_api.

This changes delays the reading of the environment variables to the moment a setting is used, taking away this effect.

Feel free to give your honest feedback, and if you prefer a different implementation of this, also feel free to let me know. This was a relative quick change to make for me, so not a huge time investment on my part.